### PR TITLE
Don't process default methods at all

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/ClassInfo.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/ClassInfo.java
@@ -52,8 +52,8 @@ public class ClassInfo {
         return companionClass;
     }
 
-    public void enableCompanionClass() {
-        this.companionClass = Optional.of(Type.getObjectType(type.getInternalName() + "$"));
+    public void enableCompanionClass(String name) {
+        this.companionClass = Optional.of(Type.getObjectType(name));
     }
 
     public boolean isClass() {


### PR DESCRIPTION
Hi.
I am trying to [upgrade Bck2Brwsr VM](https://github.com/jtulach/bck2brwsr/commit/3a5bb2a73cbed6edfa5593b9415584b3f7ab96d9) usage of Retrolamda from 2.1.0 to 2.5.7. I am facing problems. Bck2Brwsr doesn't need help with default methods, only with lamdas. Looks like that version 2.5.7 isn't really ready for that.

This change, together with [3a5bb2a](https://github.com/jtulach/bck2brwsr/commit/3a5bb2a73cbed6edfa5593b9415584b3f7ab96d9) change seem to do the trick. Can you please review them and accept or suggest better way to do what is necessary?

One surprising issue is that I have to call [analyzer.analyse myself](https://github.com/jtulach/bck2brwsr/commit/3a5bb2a73cbed6edfa5593b9415584b3f7ab96d9#diff-b3f7356c0ca20e1d8e78ee801f8bf2e65a28ab0d0538a1cf275f733708e06bcdR119) as it is not called when `defaultMethodsEnabled` is `false`.

Then I needed to somehow disable creation of the companion class. The `protected` method which [allows me to return existing class name](https://github.com/jtulach/bck2brwsr/commit/3a5bb2a73cbed6edfa5593b9415584b3f7ab96d9#diff-b3f7356c0ca20e1d8e78ee801f8bf2e65a28ab0d0538a1cf275f733708e06bcdR51) seems to do the trick.

My changes just outline what is necessary. I am sure you can come up with better fixes.

Btw. it  maybe hard to test with `defaultMethodsEnabled` being off - if you are interested, I could prepare some testcase using Bck2Brwsr AOT compilation & execution. It might make upgrading to new retrolambda version less painful in the future.